### PR TITLE
Update Serial.java

### DIFF
--- a/src/android/fr/drangies/cordova/serial/Serial.java
+++ b/src/android/fr/drangies/cordova/serial/Serial.java
@@ -208,7 +208,7 @@ public class Serial extends CordovaPlugin {
                     driver = availableDrivers.get(0);
                     UsbDevice device = driver.getDevice();
                     // create the intent that will be used to get the permission
-                    PendingIntent pendingIntent = PendingIntent.getBroadcast(cordova.getActivity(), 0, new Intent(UsbBroadcastReceiver.USB_PERMISSION), 0);
+                    PendingIntent pendingIntent = PendingIntent.getBroadcast(cordova.getActivity(), 0, new Intent(UsbBroadcastReceiver.USB_PERMISSION), PendingIntent.FLAG_MUTABLE);
                     // and a filter on the permission we ask
                     IntentFilter filter = new IntentFilter();
                     filter.addAction(UsbBroadcastReceiver.USB_PERMISSION);


### PR DESCRIPTION
Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
    Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
        at android.app.PendingIntent.checkFlags(PendingIntent.java:408)
        at android.app.PendingIntent.getBroadcastAsUser(PendingIntent.java:688)
        at android.app.PendingIntent.getBroadcast(PendingIntent.java:675)
        at fr.drangies.cordova.serial.Serial$2.run(Serial.java:211)